### PR TITLE
correct variable name

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -35,7 +35,7 @@ module.exports = function(options) {
 		port: argv.p || argv.port || 11311
 	}, options.gogoShellConfig);
 	options.pathDist = options.pathDist || 'dist';
-	options.rootDir = options.rootDir || 'docroot';
+	options.pathSrc = options.pathSrc || 'docroot';
 	options.storeConfig = _.assign({
 		name: 'LiferayPlugin',
 		path: 'liferay-plugin.json'

--- a/tasks/war.js
+++ b/tasks/war.js
@@ -11,7 +11,7 @@ module.exports = function(options) {
 	gulp.task(TASK_PLUGIN_WAR, function() {
 		return gulp.src(path.join(options.rootDir, '**/*'))
 			.pipe(zip(options.distName + '.war'))
-			.pipe(gulp.dest(options.pathDist));
+			.pipe(gulp.dest(options.pathSrc));
 	});
 
 	gulp.task('build', [TASK_PLUGIN_WAR]);

--- a/test/index.js
+++ b/test/index.js
@@ -82,7 +82,7 @@ test.cb.serial('registerTasks should invoke extension functions', function(t) {
 			},
 			gulp: gulp,
 			pathDist: 'dist',
-			rootDir: 'docroot',
+			pathSrc: 'docroot',
 			storeConfig: {
 				name: 'LiferayPlugin',
 				path: 'liferay-plugin.json'


### PR DESCRIPTION
According to the [documentation](https://github.com/liferay/liferay-theme-tasks#options) , we use `pathSrc` to set the source folder/directory not `rootDir` (I am aware it is a different project). I noticed this when I wrongly used `pathSrc` option in `gulpfile.js` to set the source folder/directory after I renamed `docroot` to `src`. Shouldn't we use the same `option` names in both projects?
