### PR TITLE
Add new parameterized init task

### DIFF
--- a/lib/init_prompt.js
+++ b/lib/init_prompt.js
@@ -83,7 +83,7 @@ InitPrompt.prototype = {
 					name: 'appServerPath',
 					type: 'input',
 					validate: instance._validateAppServerPath,
-					when: instance._appServerPathWhen(options)
+					when: instance._appServerPathWhen(options, instance._validateAppServerPath)
 				},
 				{
 					default: instance._getDefaultDeployPath,
@@ -106,10 +106,15 @@ InitPrompt.prototype = {
 	},
 
 
-	_appServerPathWhen: function(options){
+	_appServerPathWhen: function(options, validate){
 		return function(answers){
-			if (options.appServerPathArgv){
-				answers.appServerPath = options.appServerPathArgv;
+			var valid = validate(options.argv.appServerPath);
+			/*
+				Since _validateAppServerPath can return a string or boolean, 
+				need to verify it is boolean true and not string truthy value
+			*/
+			if (options.argv.appServerPath && typeof (valid) === 'boolean' && valid){
+				answers.appServerPath = options.argv.appServerPath;
 				return false;
 			} else {
 				return true;
@@ -119,8 +124,8 @@ InitPrompt.prototype = {
 
 	_urlWhen: function(options){
 		return function(answers){
-			if (options.urlArgv){
-				answers.url = options.urlArgv;
+			if (options.argv.url){
+				answers.url = options.argv.url;
 				return false;
 			} else {
 				return true;

--- a/lib/init_prompt.js
+++ b/lib/init_prompt.js
@@ -14,7 +14,15 @@ function InitPrompt(options, cb) {
 	instance.done = cb;
 	instance.store = options.store;
 
-	instance._prompt(options);
+	if (options.shouldPrompt){
+		instance._prompt(options);
+	} else {
+		instance._afterPrompt({
+			appServerPath: options.appServerPath,
+			deployPath: instance._getDefaultDeployPath(options),
+			url: options.url
+		});
+	}
 }
 
 InitPrompt.prototype = {

--- a/lib/init_prompt.js
+++ b/lib/init_prompt.js
@@ -82,7 +82,8 @@ InitPrompt.prototype = {
 					message: 'Enter the path to your app server directory:',
 					name: 'appServerPath',
 					type: 'input',
-					validate: instance._validateAppServerPath
+					validate: instance._validateAppServerPath,
+					when: instance._appServerPathWhen(options)
 				},
 				{
 					default: instance._getDefaultDeployPath,
@@ -96,11 +97,35 @@ InitPrompt.prototype = {
 					default: 'http://localhost:8080',
 					message: 'Enter the url to your production or development site:',
 					name: 'url',
-					type: 'input'
+					type: 'input',
+					when: instance._urlWhen(options)
 				}
 			],
 			_.bind(instance._afterPrompt, instance)
 		);
+	},
+
+
+	_appServerPathWhen: function(options){
+		return function(answers){
+			if (options.appServerPathArgv){
+				answers.appServerPath = options.appServerPathArgv;
+				return false;
+			} else {
+				return true;
+			}
+		}
+	},
+
+	_urlWhen: function(options){
+		return function(answers){
+			if (options.urlArgv){
+				answers.url = options.urlArgv;
+				return false;
+			} else {
+				return true;
+			}
+		}
 	},
 
 	_validateAppServerPath: function(appServerPath) {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "lodash": "^4.6.1",
     "minimist": "^1.2.0",
     "require-directory": "^2.1.1",
-    "run-sequence": "^1.1.5"
+    "run-sequence": "^1.1.5",
+    "yargs": "^6.6.0"
   },
   "devDependencies": {
     "ava": "^0.15.2",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,7 @@
     "lodash": "^4.6.1",
     "minimist": "^1.2.0",
     "require-directory": "^2.1.1",
-    "run-sequence": "^1.1.5",
-    "yargs": "^6.6.0"
+    "run-sequence": "^1.1.5"
   },
   "devDependencies": {
     "ava": "^0.15.2",

--- a/tasks/init.js
+++ b/tasks/init.js
@@ -2,7 +2,6 @@
 
 var InitPrompt = require('../lib/init_prompt');
 var path = require('path');
-var argv = require('minimist')(process.argv.slice(2));
 
 var TASK_PLUGIN_INIT = 'plugin:init';
 
@@ -15,8 +14,7 @@ module.exports = function(options) {
 		new InitPrompt({
 			appServerPathDefault: store.get('appServerPath') || path.join(path.dirname(process.cwd()), 'tomcat'),
 			store: store,
-			appServerPathArgv: argv.appServerPath,
-			urlArgv: argv.url
+			argv: options.argv
 		}, cb);
 	});
 

--- a/tasks/init.js
+++ b/tasks/init.js
@@ -2,8 +2,11 @@
 
 var InitPrompt = require('../lib/init_prompt');
 var path = require('path');
+var argv = require('yargs').argv;
+var gutil = require('gulp-util');
 
 var TASK_PLUGIN_INIT = 'plugin:init';
+var TASK_PLUGIN_INIT_PARAMETERIZED = 'plugin:initParameterized';
 
 module.exports = function(options) {
 	var gulp = options.gulp;
@@ -13,8 +16,26 @@ module.exports = function(options) {
 	gulp.task(TASK_PLUGIN_INIT, function(cb) {
 		new InitPrompt({
 			appServerPathDefault: store.get('appServerPath') || path.join(path.dirname(process.cwd()), 'tomcat'),
-			store: store
+			store: store,
+			shouldPrompt: true
 		}, cb);
+	});
+
+	gulp.task(TASK_PLUGIN_INIT_PARAMETERIZED, function(cb) {
+		var appServerPath = argv.appServerPath || false;
+		var url = argv.url || false;
+		
+		if(appServerPath && url){
+			new InitPrompt({
+				appServerPath: appServerPath,
+				url: url,
+				store: store,
+				shouldPrompt: false
+			}, cb);
+		} else {
+			gutil.log("Missing Parameters.  Please run 'gulp plugin:initParameterized' with --appServerPath and --url parameters");
+			process.exit();
+		}
 	});
 
 	gulp.task('init', [TASK_PLUGIN_INIT]);

--- a/tasks/init.js
+++ b/tasks/init.js
@@ -2,6 +2,7 @@
 
 var InitPrompt = require('../lib/init_prompt');
 var path = require('path');
+var argv = require('minimist')(process.argv.slice(2));
 
 var TASK_PLUGIN_INIT = 'plugin:init';
 
@@ -13,7 +14,9 @@ module.exports = function(options) {
 	gulp.task(TASK_PLUGIN_INIT, function(cb) {
 		new InitPrompt({
 			appServerPathDefault: store.get('appServerPath') || path.join(path.dirname(process.cwd()), 'tomcat'),
-			store: store
+			store: store,
+			appServerPathArgv: argv.appServerPath,
+			urlArgv: argv.url
 		}, cb);
 	});
 

--- a/test/lib/init_prompt.js
+++ b/test/lib/init_prompt.js
@@ -19,6 +19,15 @@ function getDefaultAnswers() {
 	};
 }
 
+function getOptionsForArgv() {
+	return {
+		argv: {
+			appServerPath: path.join(__dirname, '../fixtures/server/tomcat'),
+			url: 'http://localhost:8080'
+		}
+	};
+}
+
 test.before(function() {
 	process.chdir(path.join(__dirname, '../..'));
 
@@ -148,6 +157,29 @@ test('_prompt should invoke inquirer.prompt with correct args', function(t) {
 	t.true(_.isFunction(args[1]), 'second argument is a callback function');
 
 	inquirer.prompt = prompt;
+});
+
+test('_appServerPathWhen should properly determine when to prompt for appServerPath', function(t){
+	var options = getOptionsForArgv();
+	var validate = prototype._validateAppServerPath;
+	var result = prototype._appServerPathWhen(options, validate)({});
+
+	t.false(result, 'should not prompt for input');
+
+	result = prototype._appServerPathWhen({argv: {}}, validate)({});
+	
+	t.true(result, 'should prompt for input when no argv provided');
+});
+
+test('_urlWhen should properly determine when to prompt for url', function(t){
+	var options = getOptionsForArgv();
+	var result = prototype._urlWhen(options)({});
+
+	t.false(result, 'should not prompt for input');
+
+	result = prototype._urlWhen({argv: {}})({});
+	
+	t.true(result, 'should prompt for input when no argv provided');
 });
 
 test('_validateAppServerPath should properly validate path and return appropriate messages if invalid', function(t) {


### PR DESCRIPTION
Add a new gulp task 'plugin:initParameterized' to allow for the configuration json file to be created by passing in command line agruments instead of requiring a prompt.  

This will be useful, as it will make it much easier to run the init task in bash or powershell scripts.  Instead of having to prompt the user for input each time the init task is ran, the appServerPath and url can now be stored in variables and passed to the parameterized init.  

I would be willing to write unit tests if required to be merged, however, I'm not sure what the best way to mock receiving command line arguments would be, since I'm currently reading directly from yargs.