### PR TITLE
Add support for GlassFish, JBoss and Wildfly application servers

### DIFF
--- a/lib/init_prompt.js
+++ b/lib/init_prompt.js
@@ -118,15 +118,14 @@ InitPrompt.prototype = {
 				retVal = '"%s" is not a directory';
 			}
 			else {
-				var baseName = path.basename(appServerPath);
+				var glassfishPath = path.join(appServerPath, 'domains');
+				var jbossPath = path.join(appServerPath, 'standalone/deployments');
+				var tomcatPath = path.join(appServerPath, 'webapps');
 
-				if (baseName == 'webapps') {
-					appServerPath = path.dirname(appServerPath);
+				if ((fs.existsSync(glassfishPath) && fs.statSync(glassfishPath).isDirectory()) || (fs.existsSync(jbossPath) && fs.statSync(jbossPath).isDirectory()) || (fs.existsSync(tomcatPath) && fs.statSync(tomcatPath).isDirectory())) {
+					return retVal;
 				}
-
-				var webappsPath = path.join(appServerPath, 'webapps');
-
-				if (!fs.existsSync(webappsPath) || !fs.statSync(webappsPath).isDirectory()) {
+				else {
 					retVal = '"%s" doesn\'t appear to be an app server directory';
 				}
 			}

--- a/test/fixtures/server/glassfish/domains/.gitignore
+++ b/test/fixtures/server/glassfish/domains/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/fixtures/server/jboss/standalone/deployments/.gitignore
+++ b/test/fixtures/server/jboss/standalone/deployments/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/fixtures/server/wildfly/standalone/deployments/.gitignore
+++ b/test/fixtures/server/wildfly/standalone/deployments/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/test/lib/init_prompt.js
+++ b/test/lib/init_prompt.js
@@ -172,8 +172,4 @@ test('_validateAppServerPath should properly validate path and return appropriat
 	retVal = prototype._validateAppServerPath(defaultAnswers.appServerPath);
 
 	t.true(retVal, 'path is valid');
-
-	retVal = prototype._validateAppServerPath(defaultAnswers.webappsPath);
-
-	t.true(retVal, 'pointing to webapps is valid');
 });

--- a/test/lib/init_prompt.js
+++ b/test/lib/init_prompt.js
@@ -169,7 +169,19 @@ test('_validateAppServerPath should properly validate path and return appropriat
 
 	t.true(/doesn't appear to be an app server directory/.test(retVal));
 
-	retVal = prototype._validateAppServerPath(defaultAnswers.appServerPath);
+	retVal = prototype._validateAppServerPath(path.join(__dirname, '../fixtures/server/glassfish'));
 
-	t.true(retVal, 'path is valid');
+	t.true(retVal, 'glassfish path is valid');
+
+	retVal = prototype._validateAppServerPath(path.join(__dirname, '../fixtures/server/jboss'));
+
+	t.true(retVal, 'jboss path is valid');
+
+	retVal = prototype._validateAppServerPath(path.join(__dirname, '../fixtures/server/tomcat'));
+
+	t.true(retVal, 'tomcat path is valid');
+
+	retVal = prototype._validateAppServerPath(path.join(__dirname, '../fixtures/server/wildfly'));
+
+	t.true(retVal, 'wildfly path is valid');
 });


### PR DESCRIPTION
Hey @Robert-Frampton,

686471f fixes the issue we were discussing earlier today. I tested that it works when the app server directory provided is valid and that it fails as expected when it is invalid.

- I want to note that I removed this check (https://github.com/Robert-Frampton/liferay-plugin-node-tasks/compare/master...dustinryerson:expand-app-server-support?expand=1#diff-3189ede36063608e1660faa1af3af85fL123) and am just assuming that the path provided is the app server home directory only. If you'd like me to add checks in there for each app server rather than removing the check I can do that.
- For https://github.com/Robert-Frampton/liferay-plugin-node-tasks/pull/4/files#diff-3189ede36063608e1660faa1af3af85fR122 Wildfly and JBoss app servers have the same directory structure. I used jboss for the variable name but we can change it to be something like `jbossWildflyPath` if you think that's better.

Please let me know if you have any questions or concerns.

Thanks!